### PR TITLE
ci: pause HR workflow by disabling cron jobs

### DIFF
--- a/.github/workflows/process_replies.yml
+++ b/.github/workflows/process_replies.yml
@@ -4,9 +4,9 @@ name: Hourly HR Reply Processing
 # Controls when the workflow will run
 on:
   # Runs on a schedule (cron job)
-  schedule:
-    # This runs at the beginning of every hour
-    - cron: '0 * * * *'
+  # schedule:
+  #   # This runs at the beginning of every hour
+  #   - cron: '0 * * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/send_offers.yml
+++ b/.github/workflows/send_offers.yml
@@ -4,9 +4,9 @@ name: Daily HR Schedule Offer Run
 # Controls when the workflow will run
 on:
   # Runs on a schedule (cron job)
-  schedule:
-    # This is for 17:00 CEST (15:00 UTC) every day
-    - cron: '0 15 * * *'
+  # schedule:
+  #   # This is for 17:00 CEST (15:00 UTC) every day
+  #   - cron: '0 15 * * *'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
The HR workflow is paused by commenting out the cron schedules in the GitHub Actions.

This prevents the daily and hourly execution of the `send_offers` and `process_replies` workflows.